### PR TITLE
Require Node 16 or greater

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [16.x, 18.x, 20.x]
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Explicitly require Node 16 or greater
+
 ## [0.0.3]
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "engines": {
+    "node": ">=16.0.0"
+  },
   "dependencies": {
     "better-sqlite3": "^7.4.5",
     "debug": "^4.1.1"


### PR DESCRIPTION
This package wasn't explicit about which version of Node.js it required. In other words, it didn't set the ["engines" field in package.json][0].

This changes that. I chose Node 16 because [that is the latest supported version][1].

Setting the engine won't stop anyone from installing the library on old Node—it just gives a warning and may not work for them.

Nobody asked me to do this, so feel free to reject or ask for changes. (I'm doing this because it will make it easier to update the `better-sqlite3` dependency, which is on an old version that's giving me trouble.)

[0]: https://docs.npmjs.com/cli/v9/configuring-npm/package-json?v=true#engines
[1]: https://github.com/nodejs/Release/blob/6a881a11363eb601f17b2d46e3f1664db5ce2a3b/README.md