### PR TITLE
Update to use module

### DIFF
--- a/scripts/generate-json-from-db.js
+++ b/scripts/generate-json-from-db.js
@@ -2,9 +2,11 @@
 
 /*eslint no-console: 0*/
 
-const path = require("path");
+import path from "path";
+import { fileURLToPath } from "url";
+import hostingDB from "../src/hosting-database.js";
 
-const hostingDB = require("../src/hosting-database");
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const dbPath = path.resolve(__dirname, "..", "data", "url2green.db");
 


### PR DESCRIPTION
The old version didn't work with the updated version of url2green.

Also it seems like the last versions of the database https://admin.thegreenwebfoundation.org/admin/green-urls is empty. When I tried the 19th of December is the last one with any data, the others are just empty files.